### PR TITLE
Handle GitHub Markdown Emoji

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 theme: jekyll-theme-cayman
+plugins:
+  - jemoji


### PR DESCRIPTION
Add jemoji plugin to _config.yml so that emoji render properly

Before:
![image](https://user-images.githubusercontent.com/7570458/125538493-b49ae4a4-796f-4674-b450-8831b189eaba.png)

After:
![image](https://user-images.githubusercontent.com/7570458/125538511-34ccb9de-6882-4852-a4e3-df057d81b3a9.png)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>